### PR TITLE
use existing filter to remove bgseo robots output

### DIFF
--- a/includes/class-boldgrid-inspirations-attribution-page.php
+++ b/includes/class-boldgrid-inspirations-attribution-page.php
@@ -286,7 +286,7 @@ class Boldgrid_Inspirations_Attribution_Page {
 
 		// Ensure the Attribute page is noindex.
 		add_action( 'wp_head', 'wp_no_robots' );
-		add_filter( 'boldgrid-seo/seo/robots/run', '__return_false' );
+		remove_all_actions( 'boldgrid-seo/seo/robots' );
 	}
 
 	/**


### PR DESCRIPTION
see comment on [BoldGrid/boldgrid-seo#19](https://github.com/BoldGrid/boldgrid-seo/issues/19) for reference.  

This uses the preexisting filter in bgseo to remove the robots output instead of adding a new filter for this one off case.  So the superfluous addition of `boldgrid-seo/seo/robots/run` can be reverted in bgseo repo which will help keep the existing filters on output methods unified in that plugin.  There have been a few support tickets where filters in boldgrid-seo were modified, and the [BoldGrid/boldgrid-seo-anspress-extension](https://github.com/BoldGrid/boldgrid-seo-anspress-extension) makes use of the filters as an officially released plugin that extends boldgrid-seo.

`boldgrid-seo/seo/robots/run` was added to inspirations when implementing #49 for further reference if needed.