### PR TITLE
added $transient->no_update field

### DIFF
--- a/includes/class-boldgrid-inspirations-update.php
+++ b/includes/class-boldgrid-inspirations-update.php
@@ -563,6 +563,13 @@ class Boldgrid_Inspirations_Update {
 					if ( isset( $transient->response[ $slug ] ) ) {
 						unset( $transient->response[ $slug ] );
 					}
+
+					/*
+					 * In order for a theme to be compatible with the Auto Updates UI
+					 * in WordPress 5.5, it must return a no_update value in this transient
+					 * when there are no updates available
+					 */
+					$transient->no_update[ $slug ] = $installed_theme;
 				}
 			}
 		}


### PR DESCRIPTION
This resolves the issue where V1 themes in inspirations do not allow the user to Enable / Disable updates using the new WordPress 5.5 UI . This is per the recommendations of WordPress here:
[Recommended usage of the Updates API to support the auto-updates UI for Plugins and Themes in WordPress 5.5](https://make.wordpress.org/core/tag/feature-autoupdates/)