### PR TITLE
Disable menu reordering by default. Fixes #54

### DIFF
--- a/assets/js/base-admin.js
+++ b/assets/js/base-admin.js
@@ -162,7 +162,7 @@ IMHWPB.BaseAdmin = function( $ ) {
 			useAdminMenu = IMHWPB.configs.settings.boldgrid_menu_option;
 		}
 
-		if ( 1 == useAdminMenu && 'undefined' != typeof pagenow && 'dashboard-network' != pagenow ) {
+		if ( useAdminMenu && 'undefined' != typeof pagenow && 'dashboard-network' != pagenow ) {
 
 			// Configure the correct link.
 			var correct_link = 'customize.php?return=' + returnUrl;

--- a/includes/class-boldgrid-inspirations-config.php
+++ b/includes/class-boldgrid-inspirations-config.php
@@ -126,6 +126,19 @@ class Boldgrid_Inspirations_Config {
 	}
 
 	/**
+	 * Reset our configs.
+	 *
+	 * This is useful for pages where the configs are changed mid page load. This class caches the
+	 * configs (see the first lines of self::get_format_configs()). If the configs are changed mid
+	 * page load, we'll need to reset that cache.
+	 *
+	 * @since SINCEVERSION
+	 */
+	public static function reset_configs() {
+		self::$configs = array();
+	}
+
+	/**
 	 * Configure default settings.
 	 *
 	 * Pass in an array of BoldGrid settings. For our default settings, set those defaults in the
@@ -145,7 +158,8 @@ class Boldgrid_Inspirations_Config {
 		}
 
 		$defaults = array(
-			'boldgrid_menu_option' => '1',
+			// By default, do not rearrange the dashboard menus.
+			'boldgrid_menu_option' => '0',
   			'boldgrid_feedback_optout' => '0',
   			'release_channel' => 'stable',
   			'theme_release_channel' => 'stable',

--- a/includes/class-boldgrid-inspirations-dashboard.php
+++ b/includes/class-boldgrid-inspirations-dashboard.php
@@ -35,20 +35,6 @@ class Boldgrid_Inspirations_Dashboard extends Boldgrid_Inspirations {
 	 * Add hooks.
 	 */
 	public function add_hooks() {
-		// Get BoldGrid settings from the blog's WP option.
-		$boldgrid_settings_blog = get_option( 'boldgrid_settings' );
-
-		// If value returned is not an integer.
-		if ( ! isset( $boldgrid_settings_blog['boldgrid_menu_option'] ) ||
-			! is_int( $boldgrid_settings_blog['boldgrid_menu_option'] ) ) {
-
-			// Then set key in array to our default menu arrangement value (1).
-			$boldgrid_settings_blog['boldgrid_menu_option'] = '1';
-
-			// Update blog WP option.
-			update_option( 'boldgrid_settings', $boldgrid_settings_blog );
-		}
-
 		if ( is_admin() ) {
 			Boldgrid_Inspirations_Feedback::enqueue_js();
 
@@ -59,9 +45,6 @@ class Boldgrid_Inspirations_Dashboard extends Boldgrid_Inspirations {
 				)
 			);
 
-			// grab array of settings for boldgrid from database
-			$boldgrid_menu_options = get_option( 'boldgrid_settings' );
-
 			// if in admin add CSS and JS to dashboard for widget and styling
 			add_action( 'admin_enqueue_scripts',
 				array(
@@ -71,7 +54,7 @@ class Boldgrid_Inspirations_Dashboard extends Boldgrid_Inspirations {
 			);
 
 			// If option is marked to rearrange admin menus.
-			if ( 1 == $boldgrid_menu_options['boldgrid_menu_option'] ) {
+			if ( Boldgrid_Inspirations_Config::use_boldgrid_menu() ) {
 				/*
 				 * Check if we are using multisite or not, then change our hook location and
 				 * priority accordingly.
@@ -135,14 +118,7 @@ class Boldgrid_Inspirations_Dashboard extends Boldgrid_Inspirations {
 
 	// Rearrange our plugin menu items into single menu item.
 	public function boldgrid_admin_one_menu_add() {
-
-		// Grab array of settings again.
-		$boldgrid_menu_options = get_option( 'boldgrid_settings' );
-
-		// Check key for value of boldgrid_menu_option and remove boldgrid-inspirations menu if we
-		// are using single menu system.
-		empty( $boldgrid_menu_options['boldgrid_menu_option'] ) ?
-		remove_menu_page( 'boldgrid-inspirations' ) : false;
+		! Boldgrid_Inspirations_Config::use_boldgrid_menu() ? remove_menu_page( 'boldgrid-inspirations' ) : false;
 
 		// Define our menu name.
 		$top_level_menu = 'boldgrid-inspirations';

--- a/includes/class-boldgrid-inspirations-inspiration.php
+++ b/includes/class-boldgrid-inspirations-inspiration.php
@@ -488,7 +488,7 @@ public function add_boldgrid_configs_to_header() {
 	if( false === $this->allow_header_configs() ) {
 		$configs = array(
 			'settings' => array(
-				'boldgrid_menu_option' => $configs['settings']['boldgrid_menu_option'],
+				'boldgrid_menu_option' => Boldgrid_Inspirations_Config::use_boldgrid_menu(),
 			),
 		);
 	}

--- a/includes/class-boldgrid-inspirations-options.php
+++ b/includes/class-boldgrid-inspirations-options.php
@@ -159,13 +159,11 @@ class Boldgrid_Inspirations_Options {
 	 * Callback for menu reordering.
 	 */
 	public function boldgrid_menu_callback() {
-		$options = get_option( 'boldgrid_settings' );
-
 		?>
 <input type="checkbox" id="boldgrid_menu_option"
 name="boldgrid_settings[boldgrid_menu_option]" value="1"
 		<?php
-		echo checked( 1, ( bool ) $options['boldgrid_menu_option'], false );
+		echo checked( 1, Boldgrid_Inspirations_Config::use_boldgrid_menu(), false );
 		?> />
 <label for="boldgrid_menu_option"><?php esc_html_e( 'Use BoldGrid Admin Menu system', 'boldgrid-inspirations' ); ?></label>
 		<?php
@@ -286,6 +284,9 @@ name='boldgrid_settings[boldgrid_feedback_optout]' value='1'
 
 		// Save updated settings.
 		update_option( 'boldgrid_settings', $boldgrid_settings );
+
+		// Reset cache of settings just saved.
+		Boldgrid_Inspirations_Config::reset_configs();
 
 		include BOLDGRID_BASE_DIR . '/pages/templates/settings-saved.php';
 

--- a/includes/class-boldgrid-inspirations-purchase-coins.php
+++ b/includes/class-boldgrid-inspirations-purchase-coins.php
@@ -25,9 +25,7 @@ class Boldgrid_Inspirations_Purchase_Coins extends Boldgrid_Inspirations {
 	 */
 	public function add_hooks() {
 		if ( is_admin() ) {
-			$boldgrid_menu_options = get_option( 'boldgrid_settings' );
-
-			( 1 == $boldgrid_menu_options['boldgrid_menu_option'] ? add_action( 'admin_menu',
+			( Boldgrid_Inspirations_Config::use_boldgrid_menu() ? add_action( 'admin_menu',
 				array (
 					$this,
 					'menu_purchase_coins'
@@ -43,9 +41,7 @@ class Boldgrid_Inspirations_Purchase_Coins extends Boldgrid_Inspirations {
 	 * Purchase Coins submenu item.
 	 */
 	public function menu_purchase_coins() {
-		$boldgrid_settings = get_option( 'boldgrid_settings' );
-
-		( 1 == $boldgrid_settings['boldgrid_menu_option'] ? add_submenu_page(
+		( Boldgrid_Inspirations_Config::use_boldgrid_menu() ? add_submenu_page(
 			'boldgrid-transactions', __( 'Purchase Coins', 'boldgrid-inspirations' ), __( 'Purchase Coins', 'boldgrid-inspirations' ), 'administrator',
 			'boldgrid-purchase-coins', array (
 				$this,

--- a/includes/class-boldgrid-inspirations-purchase-for-publish.php
+++ b/includes/class-boldgrid-inspirations-purchase-for-publish.php
@@ -767,9 +767,7 @@ class Boldgrid_Inspirations_Purchase_For_Publish extends Boldgrid_Inspirations {
 
 	// Add the cart submenu page
 	public function cart_checkout() {
-		$boldgrid_menu_options = get_option( 'boldgrid_settings' );
-
-		if ( 1 == $boldgrid_menu_options['boldgrid_menu_option'] ) {
+		if ( Boldgrid_Inspirations_Config::use_boldgrid_menu() ) {
 			add_submenu_page(
 				'boldgrid-transactions',
 				esc_html__( 'Cart', 'boldgrid-inspirations' ),

--- a/includes/class-boldgrid-inspirations-update.php
+++ b/includes/class-boldgrid-inspirations-update.php
@@ -191,11 +191,8 @@ class Boldgrid_Inspirations_Update {
 	 * @access private
 	 */
 	private function set_notice_params() {
-		// Get boldgrid settings.
-		$boldgrid_settings = get_option( 'boldgrid_settings' );
-
 		// Get the boldgrid menu option from settings.
-		$this->notice_params['boldgrid_menu_option'] = $boldgrid_settings['boldgrid_menu_option'];
+		$this->notice_params['boldgrid_menu_option'] = Boldgrid_Inspirations_Config::use_boldgrid_menu();
 
 		if ( ! function_exists( 'get_plugin_data' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION
Testing:
1. Use a plugin like WP Reset to reset your site
2. Activate Inspirations. Make sure the custom menu is not activated by default.
3. Change the settings. Make sure they work as expected. On saving the page, the menu won't be updated until the 2nd page load, but make sure the setting saved.