### PR TITLE
Use correct hook to add Connect Search Menu item

### DIFF
--- a/includes/class-boldgrid-inspirations-stock-photography.php
+++ b/includes/class-boldgrid-inspirations-stock-photography.php
@@ -96,7 +96,7 @@ class Boldgrid_Inspirations_Stock_Photography extends Boldgrid_Inspirations {
 					'register_boldgrid_connect_search_page'
 				) );
 
-			add_action( 'admin_notices', array (
+			add_action( 'admin_menu', array (
 				$this,
 				'add_dashboard_media_tabs'
 			) );


### PR DESCRIPTION
The menu item under Media for Connect Search is currently added with the admin_notices hook, not the admin_menu hook. This is causing a conflict with Gravity Forms and is not best-practice. @bwmarkle can you review?