### PR TITLE
do not display theme categories

### DIFF
--- a/assets/js/boldgrid-inspirations.js
+++ b/assets/js/boldgrid-inspirations.js
@@ -1357,7 +1357,10 @@ IMHWPB.InspirationsDesignFirst = function( $, configs ) {
 	 * @since 1.2.3
 	 */
 	this.initCategories = function() {
-		var failureMessage, failAction, success_action;
+		var template = wp.template( 'init-categories' ),
+			failureMessage,
+			failAction,
+			success_action;
 
 		// Show a loading message to the user that we're fetching categories.
 		self.$categories.html( Inspiration.fetchingCategories + ' <span class="spinner inline"></span>' );
@@ -1418,12 +1421,49 @@ IMHWPB.InspirationsDesignFirst = function( $, configs ) {
 			}
 		};
 
-		self.ajax.ajaxCall(
-			{ inspirations_mode: 'standard' },
-			'get_categories',
-			success_action,
-			failAction
-		);
+		/**
+		 * We are now only going to display the 'default' category on the stable release channel.
+		 *
+		 * Rather than remove the code that fetches categories, we will just hide the categories
+		 * in case we need to revert back to the old behavior, or if we need to display categories
+		 * for development / test releases. This method easily allows for them to be displayed if the
+		 * user has selected a non-stable release channel.
+		 *
+		 * Adding this logic here, rather than inside the 'success_action' callback, also prevents making
+		 * an unnecessary API call to fetch the categories list.
+		 */
+		if ( 'stable' === self.themeReleaseChannel ) {
+			template                = wp.template( 'init-categories' );
+			self.categories         = {};
+			self.categories.default = {
+				subcategories: [
+					{
+						displayOrder: 1,
+						name: 'Default',
+						id: 'default'
+					}
+				]
+			};
+
+			console.log( { releaseChannel: self.themeReleaseChannel, categories: self.categories } );
+
+			self.$categories.html( template( self.categories ) );
+
+			self.sortCategories( 'data-display-order' );
+
+			self.initThemes();
+
+			$( '#screen-design #categories.left' ).hide();
+			$( '#screen-design #categories.left .sub-category.active' ).hide();
+			$( '#screen-design .right.theme-browser' ).css( 'width', '100%' );
+		} else {
+			self.ajax.ajaxCall(
+				{ inspirations_mode: 'standard' },
+				'get_categories',
+				success_action,
+				failAction
+			);
+		}
 	};
 
 	/**
@@ -1616,6 +1656,11 @@ IMHWPB.InspirationsDesignFirst = function( $, configs ) {
 					defaultBuilds++;
 					self.$themes.append( template( { configs: IMHWPB.configs, build: build } ) );
 					build.isDefault = false;
+				}
+
+				// On the stable release channel, we only display 'default' themes category.
+				if ( 'stable' === self.themeReleaseChannel ) {
+					return;
 				}
 
 				/**

--- a/pages/templates/boldgrid-inspirations.php
+++ b/pages/templates/boldgrid-inspirations.php
@@ -1,17 +1,24 @@
 <script type="text/html" id="tmpl-init-categories">
 	<div class="category-filter" ><?php echo __( 'Categories', 'boldgrid-inspirations' ); ?></div>
 
-	<div class="sub-category active" data-display-order="0" >
-		<input type="radio" name="sub-category" checked data-sub-category-id="0" >
+	<div class="sub-category" data-display-order="0" >
+		<input type="radio" name="sub-category" data-sub-category-id="0" >
 		<span class="sub-category-name"><?php echo __( 'All', 'boldgrid-inspirations' ); ?></span>
 	</div>
 
 	<# _.each( data, function( category ) { #>
 		<# _.each( category.subcategories, function( sub_category ) { #>
 			<# if ( ! sub_category.isHiddenFromSidebar ) { #>
-				<div class="sub-category" data-display-order="{{sub_category.displayOrder}}" >
-					<input type="radio" name="sub-category" data-sub-category-id="{{sub_category.id}}"> <span class="sub-category-name">{{sub_category.name}}</span>
-				</div>
+				<# if ( 'default' === sub_category.id ) { #>
+					<div class="sub-category active" data-display-order="{{sub_category.displayOrder}}" >
+						<input type="radio" name="sub-category" checked data-sub-category-id="{{sub_category.id}}">
+						<span class="sub-category-name">{{sub_category.name}}</span>
+					</div>
+				<# } else {#>
+					<div class="sub-category" data-display-order="{{sub_category.displayOrder}}" >
+						<input type="radio" name="sub-category" data-sub-category-id="{{sub_category.id}}"> <span class="sub-category-name">{{sub_category.name}}</span>
+					</div>
+				<# } #>
 			<# } #>
 		<# }); #>
 	<# }); #>


### PR DESCRIPTION
Resolves #166 

Note: This method of handling this retains all initial functionality for edge / candidate channels, in order to allow for any future decisions to return to a category based functionality, and to also allow for testing / development of new themes easily without them appearing on 'stable' . This change essentially skips the API call to fetch the categories list, sets 'default' to the active category, and then hides the categories list if the user is on the 'stable' release channel. 

Testing instructions:
1. Checkout this branch and build.
2. Activate Inspirations
3. Proceed through the Inspirations process, noticing there should only be 'Default' themes displayed.
4. Afterwards, switch to a non-stable channel, and repeat, noticing the categories should all display as before.

