### PR TITLE
get actual site screenshot

### DIFF
--- a/includes/class-boldgrid-inspirations-deploy-api.php
+++ b/includes/class-boldgrid-inspirations-deploy-api.php
@@ -43,6 +43,32 @@ class Boldgrid_Inspirations_Deploy_Api {
 	}
 
 	/**
+	 * Get Screenshot.
+	 *
+	 * @param array $args
+	 */
+	public function get_screenshot( $args ) {
+		$api_url = $this->configs['asset_server'] . $this->configs['ajax_calls']['get_screenshot'];
+
+		$remote_post_args = array(
+			'method'  => 'POST',
+			'body'    => $args,
+			'timeout' => 20,
+		);
+
+		$response = wp_remote_retrieve_body( wp_remote_post( $api_url, $remote_post_args ) );
+		$response = json_decode( $response ? $response : '', true );
+
+		if ( $response && ! empty( $response['result']['data']['asset_id'] ) ) {
+			$asset_id = $response['result']['data']['asset_id'];
+			$key      = get_option( 'boldgrid_api_key' );
+			$url      = $this->configs['asset_server'] . '/api/asset/get?key=' . $key . '&id=' . $asset_id;
+
+			update_option( 'boldgrid_site_screenshot', $url );
+		}
+	}
+
+	/**
 	 * Get install options.
 	 *
 	 * @since 1.7.0

--- a/includes/class-boldgrid-inspirations-deploy.php
+++ b/includes/class-boldgrid-inspirations-deploy.php
@@ -1822,6 +1822,25 @@ class Boldgrid_Inspirations_Deploy {
 		 * may have added a Crio Premium service for the user. Delete license data so it can be refreshed.
 		 */
 		Boldgrid_Inspirations_Update::delete_license();
+
+		// Get a screenshot of the new site.
+		$this->get_screenshot();
+	}
+
+	/**
+	 * Get the screenshot.
+	 */
+	public function get_screenshot() {
+		$site_url = get_site_url();
+
+		$api_key_hash = $this->asset_manager->api->get_api_key_hash();
+
+		$args = array(
+			'site_url' => $site_url,
+			'key'      => $api_key_hash,
+		);
+
+		$this->api->get_screenshot( $args );
 	}
 
 	/**

--- a/includes/class-boldgrid-inspirations-my-inspiration.php
+++ b/includes/class-boldgrid-inspirations-my-inspiration.php
@@ -421,9 +421,13 @@ class Boldgrid_Inspirations_My_Inspiration {
 	 * @since 1.7.0
 	 */
 	public function box_theme() {
-		$theme = wp_get_theme(); ?>
+		$theme          = wp_get_theme();
+		$screenshot_url = get_option( 'boldgrid_site_screenshot', $theme->get_screenshot() );
+		?>
 
-		<p><img src="<?php echo esc_url( $theme->get_screenshot() ); ?>" style="max-width:100%; border:1px solid #ddd;" /></p>
+
+
+		<p><img src="<?php echo esc_url( $screenshot_url ); ?>" style="max-width:100%; border:1px solid #ddd;" /></p>
 
 	<?php }
 

--- a/includes/config/config.plugin.php
+++ b/includes/config/config.plugin.php
@@ -21,6 +21,7 @@ return array(
 		'get_install_details' =>						'/api/build/get-install-details',
 		'get_build_profile_using_in_progress_theme' =>	'/api/build/get-using-in-progress-theme',
 		'get_generic' =>								'/api/build/get-generic',
+		'get_screenshot' =>								'/api/build/get-screenshot',
 		// Pde.
 		'get_curated' =>								'/api/pde/get-curated-asset',
 		// Theme.


### PR DESCRIPTION
resolves #168 

This PR will generate a screenshot of the site just after inspirations installation, to be displayed on the 'My Inspirations' page.

This PR requires the following wpb-assets PR: [wpb-assets:#543](https://github.com/BoldGrid/wpb-assets/pull/543)

Testing instructions:

1. Install and build this branch of inspirations.
2. Point to a dev server that utilizes the proper branch of wpb-assets ( 'https://api-dev-jamesros.boldgrid.com' ) will work as of the writing of these instructions
3. Install an inspiration
4. Verify the screenshot on the My Inspirations page reflects the installation you chose.