### PR TITLE
Create utility method to get page by title

### DIFF
--- a/boldgrid-inspirations.php
+++ b/boldgrid-inspirations.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: BoldGrid Inspirations
  * Plugin URI: https://www.boldgrid.com/boldgrid-inspirations/
- * Version: 2.7.4
+ * Version: 2.7.5
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Description: Find inspiration, customize, and launch! BoldGrid Inspirations includes FREE WordPress themes and is the easiest way to launch a new WordPress site complete with custom content.

--- a/includes/class-boldgrid-inspirations-blog.php
+++ b/includes/class-boldgrid-inspirations-blog.php
@@ -79,7 +79,7 @@ class Boldgrid_Inspirations_Blog {
 	 * @since SINCEVERSION
 	 */
 	public function create_page() {
-		$page = get_page_by_title( $this->title );
+		$page = Boldgrid_Inspirations_Utility::get_page_by_title( $this->title );
 
 		if ( ! empty( $page->post_status ) && 'published' === $page->post_status ) {
 			$page_id = $page->ID;

--- a/includes/class-boldgrid-inspirations-built.php
+++ b/includes/class-boldgrid-inspirations-built.php
@@ -339,9 +339,9 @@ class Boldgrid_Inspirations_Built {
 		}
 
 		// Get default, attribution, and coming soon pages.
-		$default_page = get_page_by_title( __( 'Sample Page' ) );
-		$attribution_page = get_page_by_title( 'Attribution' );
-		$coming_soon_page = get_page_by_title( __( 'WEBSITE COMING SOON' ) );
+		$default_page     = Boldgrid_Inspirations_Utility::get_page_by_title( __( 'Sample Page' ) );
+		$attribution_page = Boldgrid_Inspirations_Utility::get_page_by_title( 'Attribution' );
+		$coming_soon_page = Boldgrid_Inspirations_Utility::get_page_by_title( __( 'WEBSITE COMING SOON' ) );
 
 		// Initialize $ids_to_remove.
 		$ids_to_filter = array();
@@ -388,7 +388,7 @@ class Boldgrid_Inspirations_Built {
 		 *
 		 * If we have an active Attribution page, exclude that from the list.
 		 */
-		$attribution_page = get_page_by_title( 'Attribution' );
+		$attribution_page = Boldgrid_Inspirations_Utility::get_page_by_title( 'Attribution' );
 
 		if ( is_object( $attribution_page ) ) {
 			$exclude = $attribution_page->ID;
@@ -408,8 +408,8 @@ class Boldgrid_Inspirations_Built {
 
 		// Get default pages we're expecting.
 		$default_pages = array(
-			'sample' => get_page_by_title( __( 'Sample Page' ) ),
-			'coming_soon' => get_page_by_title( __( 'WEBSITE COMING SOON' ) ),
+			'sample'      => Boldgrid_Inspirations_Utility::get_page_by_title( __( 'Sample Page' ) ),
+			'coming_soon' => Boldgrid_Inspirations_Utility::get_page_by_title( __( 'WEBSITE COMING SOON' ) ),
 		);
 
 		// How many of our default pages were found.

--- a/includes/class-boldgrid-inspirations-deploy.php
+++ b/includes/class-boldgrid-inspirations-deploy.php
@@ -725,12 +725,12 @@ class Boldgrid_Inspirations_Deploy {
 	 * @link https://wordpress.org/support/topic/remove-default-pages-created-on-all-multisites
 	 */
 	private function delete_sample_pages() {
-		$defaultPage = get_page_by_title( __( 'Sample Page' ) );
+		$defaultPage = Boldgrid_Inspirations_Utility::get_page_by_title( __( 'Sample Page' ) );
 		if ( $defaultPage ) {
 			wp_delete_post( $defaultPage->ID );
 		}
 
-		$defaultPage = get_page_by_title( __( 'Hello world!' ), OBJECT, 'post' );
+		$defaultPage = Boldgrid_Inspirations_Utility::get_page_by_title( __( 'Hello world!' ), OBJECT, 'post' );
 		if ( $defaultPage ) {
 			wp_delete_post( $defaultPage->ID );
 		}
@@ -2126,7 +2126,7 @@ class Boldgrid_Inspirations_Deploy {
 					$page_type = $homepage_step_obj->page->post_type;
 
 					// only create the page if it doesn't already exist
-					$existing_page = get_page_by_title( $homepage_step_obj->page->page_title,
+					$existing_page = Boldgrid_Inspirations_Utility::get_page_by_title( $homepage_step_obj->page->page_title,
 						OBJECT, $page_type );
 
 					if ( null === $existing_page ) {
@@ -2223,7 +2223,7 @@ class Boldgrid_Inspirations_Deploy {
 					break;
 
 				case 'get_permalink' :
-					$existing_page = get_page_by_title( $homepage_step_obj->page->page_title, OBJECT, $homepage_step_obj->page->post_type );
+					$existing_page = Boldgrid_Inspirations_Utility::get_page_by_title( $homepage_step_obj->page->page_title, OBJECT, $homepage_step_obj->page->post_type );
 
 					$post_id = $existing_page->ID;
 

--- a/includes/class-boldgrid-inspirations-utility.php
+++ b/includes/class-boldgrid-inspirations-utility.php
@@ -224,8 +224,13 @@ class Boldgrid_Inspirations_Utility {
 	 * This is meant to replace the deprecated
 	 * core function get_page_by_title()
 	 *
-	 * @param string $title
-	 * @return WP_POST|void
+	 * @since 2.7.5
+	 *
+	 * @param string $page_title Page title.
+	 * @param string $output Optional. Output type. OBJECT, ARRAY_N, or ARRAY_A.
+	 * @param string $post_type Optional. Post type. Default 'page'.
+	 *
+	 * @return WP_Post|null WP_Post on success or null on failure.
 	 */
 	public static function get_page_by_title( $page_title, $output = OBJECT, $post_type = 'page' ) {
 		$query = new WP_Query(

--- a/includes/class-boldgrid-inspirations-utility.php
+++ b/includes/class-boldgrid-inspirations-utility.php
@@ -217,4 +217,37 @@ class Boldgrid_Inspirations_Utility {
 
 		return $query->length !== 0 ? true : false;
 	}
+
+	/**
+	 * Get Page By Title.
+	 *
+	 * This is meant to replace the deprecated
+	 * core function get_page_by_title()
+	 *
+	 * @param string $title
+	 * @return WP_POST|void
+	 */
+	public static function get_page_by_title( $page_title, $output = OBJECT, $post_type = 'page' ) {
+		$query = new WP_Query(
+			array(
+				'title'                  => $page_title,
+				'post_type'              => $post_type,
+				'post_status'            => get_post_stati(),
+				'posts_per_page'         => 1,
+				'update_post_term_cache' => false,
+				'update_post_meta_cache' => false,
+				'no_found_rows'          => true,
+				'orderby'                => 'post_date ID',
+				'order'                  => 'ASC',
+			)
+		);
+
+		$pages = $query->posts;
+
+		if ( empty( $pages ) ) {
+			return null;
+		}
+
+		return get_post( $pages[0], $output );
+	}
 }

--- a/includes/configure_plugin/contact-form-7.php
+++ b/includes/configure_plugin/contact-form-7.php
@@ -7,7 +7,7 @@ if ( ! defined( 'WPINC' ) ) {
 	exit();
 }
 
-$auto_created_form = get_page_by_title( 'Contact form 1', 'OBJECT', 'wpcf7_contact_form' );
+$auto_created_form = Boldgrid_Inspirations_Utility::get_page_by_title( 'Contact form 1', 'OBJECT', 'wpcf7_contact_form' );
 
 $short_code = '[contact-form-7 id="' . $auto_created_form->ID . '" title="Contact form 1"]';
 


### PR DESCRIPTION
This resolves #173 

## Description ##
A little background information for this. the WP Core function `get_page_by_title()` is being deprecated as of 6.2.0 ( [see here](https://core.trac.wordpress.org/changeset/55207/trunk/src/wp-includes/deprecated.php) ) in favor of using WP_Query instead. Prior to WP 6.1 ( [see here](https://core.trac.wordpress.org/changeset/54783) ), this function already used WP_Query, pretty much in the same manor as used by the method created in this PR. It was changed due to some edge cases where a null value passed to the function would still return a page, and edge cases where the 'orderby' would not have already been set properly. Neither issues impact our usage of this method.

### Testing Instructions ###
The `get_page_by_title()` method is used by Inspirations before starting the install, and during the post / page deployment part of the installation. This method is used to determine the existence of pre-existing page / post content, and to assist in deleting posts from previous installs. 

You can test this by going through the inspirations process in various combinations of the following use cases:

1. Fresh WP install with no changes / additional content aside from what is created on WP install.
2. Inspirations install on a site with existing content, but no previous Inspiration theme install.
3. Inspirations theme install on a site with a pre-existing inspirations install.
4. Install Inspirations theme w/ Blog
5. Install Inspirations theme w/o Blog
6. Install one of the traditional Crio themes.
7. Install one of the new DreamHost Exclusive themes.
