### PR TITLE
add ability to hide 'add blog' option

### DIFF
--- a/assets/js/boldgrid-inspirations.js
+++ b/assets/js/boldgrid-inspirations.js
@@ -1512,10 +1512,10 @@ IMHWPB.InspirationsDesignFirst = function( $, configs ) {
 			pagesetSuccess;
 
 		// If the theme doesn't allow a blog, hide the blog option.
-		if ( 'true' === self.$theme.closest( '.theme' ).attr( 'data-no-blog' ) ) {
-			$( '#feature_option_blog' ).hide();
-		} else {
+		if ( 'true' === self.$theme.closest( '.theme' ).attr( 'data-allow-blog' ) ) {
 			$( '#feature_option_blog' ).show();
+		} else {
+			$( '#feature_option_blog' ).hide();
 		}
 
 		// Reset any previous error messages.

--- a/assets/js/boldgrid-inspirations.js
+++ b/assets/js/boldgrid-inspirations.js
@@ -1511,9 +1511,11 @@ IMHWPB.InspirationsDesignFirst = function( $, configs ) {
 			pagesetFail,
 			pagesetSuccess;
 
-		// If the theme doesn't allow a blog, hid the blog option.
+		// If the theme doesn't allow a blog, hide the blog option.
 		if ( 'true' === self.$theme.closest( '.theme' ).attr( 'data-no-blog' ) ) {
 			$( '#feature_option_blog' ).hide();
+		} else {
+			$( '#feature_option_blog' ).show();
 		}
 
 		// Reset any previous error messages.

--- a/assets/js/boldgrid-inspirations.js
+++ b/assets/js/boldgrid-inspirations.js
@@ -1511,6 +1511,11 @@ IMHWPB.InspirationsDesignFirst = function( $, configs ) {
 			pagesetFail,
 			pagesetSuccess;
 
+		// If the theme doesn't allow a blog, hid the blog option.
+		if ( 'true' === self.$theme.closest( '.theme' ).attr( 'data-no-blog' ) ) {
+			$( '#feature_option_blog' ).hide();
+		}
+
 		// Reset any previous error messages.
 		self.$contentNotices.html( '' );
 

--- a/includes/class-boldgrid-inspirations-purchase-for-publish.php
+++ b/includes/class-boldgrid-inspirations-purchase-for-publish.php
@@ -41,6 +41,24 @@ class Boldgrid_Inspirations_Purchase_For_Publish extends Boldgrid_Inspirations {
 	public $wp_options_asset = array();
 
 	/**
+	 * Local Publish Cost Data
+	 *
+	 * @since 2.7.6
+	 *
+	 * @var array
+	 */
+	public $local_publish_cost_data = array();
+
+	/**
+	 * Remote Publish Cost Data
+	 *
+	 * @since 2.7.6
+	 *
+	 * @var array
+	 */
+	public $remote_publish_cost_data = array();
+
+	/**
 	 * Hooks required for the PurchaseForPublish class
 	 */
 	public function add_admin_hooks() {

--- a/includes/config/survey.config.php
+++ b/includes/config/survey.config.php
@@ -6,6 +6,8 @@
  */
 
 $address = Boldgrid_Inspirations_Survey::get_value( 'address' );
+$address = $address ? $address : '';
+
 $email = Boldgrid_Inspirations_Survey::get_value( 'email' );
 $phone = Boldgrid_Inspirations_Survey::get_value( 'phone' );
 $blogname = get_option( 'blogname' );

--- a/includes/deploy/class-crio-premium-utility.php
+++ b/includes/deploy/class-crio-premium-utility.php
@@ -107,7 +107,7 @@ class Crio_Premium_Utility {
 	 */
 	public static function adjust_menu_id( $menu, $template_id ) {
 		$crio_premium_menu_locations = get_option( 'crio_premium_menu_locations', array() );
-		$menu_locations = get_theme_mod( 'nav_menu_locations' );
+		$menu_locations = get_theme_mod( 'nav_menu_locations', array() );
 		$boldgrid_survey = get_option( 'boldgrid_survey' );
 		$dnd_social_menu = isset( $boldgrid_survey['social'] ) &&
 			isset( $boldgrid_survey['social']['do-not-display'] ) &&

--- a/pages/boldgrid-inspirations.php
+++ b/pages/boldgrid-inspirations.php
@@ -331,7 +331,7 @@ if ( $show_content_warning ) {
 			</div>
 			<div class="content-menu-section">
 				<div class="feature-filter"><?php echo $lang['AddFunctionality']; ?></div>
-				<div class="feature-option">
+				<div class="feature-option" id="feature_option_blog" data-shown-pointer=false>
 					<input type="checkbox" name="install-blog" value=true /> <?php echo $lang['Blog']; ?>
 					<div id="blog-toggle" class="toggle toggle-light"></div>
 				</div>

--- a/pages/boldgrid-inspirations.php
+++ b/pages/boldgrid-inspirations.php
@@ -331,7 +331,7 @@ if ( $show_content_warning ) {
 			</div>
 			<div class="content-menu-section">
 				<div class="feature-filter"><?php echo $lang['AddFunctionality']; ?></div>
-				<div class="feature-option" id="feature_option_blog" data-shown-pointer=false>
+				<div class="feature-option" id="feature_option_blog">
 					<input type="checkbox" name="install-blog" value=true /> <?php echo $lang['Blog']; ?>
 					<div id="blog-toggle" class="toggle toggle-light"></div>
 				</div>

--- a/pages/templates/boldgrid-inspirations.php
+++ b/pages/templates/boldgrid-inspirations.php
@@ -42,6 +42,7 @@
 		data-all-order="{{allOrder}}"
 		data-category-order="{{categoryOrder}}"
 		data-is-default="{{data.build.isDefault}}"
+		data-no-blog="{{data.build.Theme.NoBlog}}"
 		data-build-id="{{data.build.Id}}">
 
 		<div class="theme-screenshot">

--- a/pages/templates/boldgrid-inspirations.php
+++ b/pages/templates/boldgrid-inspirations.php
@@ -42,7 +42,7 @@
 		data-all-order="{{allOrder}}"
 		data-category-order="{{categoryOrder}}"
 		data-is-default="{{data.build.isDefault}}"
-		data-no-blog="{{data.build.Theme.NoBlog}}"
+		data-allow-blog="{{data.build.Theme.AllowBlog}}"
 		data-build-id="{{data.build.Id}}">
 
 		<div class="theme-screenshot">


### PR DESCRIPTION
This requires an inspirations install configured to point to a dev server with the [no-blog-install branch](https://github.com/BoldGrid/wpb-assets/tree/no-blog-install) checked out, and a all propel migrations completed and autoloader updated.

Testing instructions:
1. Setup your dev api server as mentioned above.
2. Edit a theme, and set the 'No Blog' option in the `mgr/theme/view?id={themeId}` page of the dev API Admin console.
3. Install Inspirations from the disable-add-blog-feature branch.
4. Point your inspirations install to the dev api server.
5. Go through the inspirations process, choosing the theme mentioned in step 2. 
6. Ensure that the option to add a blog is not shown.