### PR TITLE
Issue 123 - Fix for 'unclosed bracket expression' error

### DIFF
--- a/includes/class-boldgrid-inspirations-purchase-for-publish.php
+++ b/includes/class-boldgrid-inspirations-purchase-for-publish.php
@@ -1333,7 +1333,7 @@ class Boldgrid_Inspirations_Purchase_For_Publish extends Boldgrid_Inspirations {
 		 * Is this image used within shortcode? For example, is image 123 used in a gallery, such as
 		 * [gallery ids='123,456'].
 		 */
-		$regexp = '[\[][^\]]+[\'\", ]' . $attachment_id . '[^0-9]+.*[\]]';
+		$regexp = '[\\\[][^\]]+[\'\", ]' . $attachment_id . '[^0-9]+.*[\]]';
 		$query = '
 			SELECT `ID`
 			FROM ' . $wpdb->posts . '


### PR DESCRIPTION
fixes #123

Several DreamHost customers are still seeing this error. Did a bit of digging and research and it turns out that there is a [bug with version 8 of mysql](https://bugs.mysql.com/bug.php?id=95347) that specifically has some issues with escapes on `[` that was causing the sequence to error out. 

Fixed the escape sequence and was able to clear the error on a customer's site. Also tested on my server with mysql version 10 with this fix and there are no errors. This was also the case for all older mysql versions I was able to test (5.5 through 5.8) 