### PR TITLE
Onboarding videos

### DIFF
--- a/boldgrid-inspirations.php
+++ b/boldgrid-inspirations.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: BoldGrid Inspirations
  * Plugin URI: https://www.boldgrid.com/boldgrid-inspirations/
- * Version: 2.8.1
+ * Version: 2.9.0
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Description: Find inspiration, customize, and launch! BoldGrid Inspirations includes FREE WordPress themes and is the easiest way to launch a new WordPress site complete with custom content.

--- a/includes/class-boldgrid-inspirations-update.php
+++ b/includes/class-boldgrid-inspirations-update.php
@@ -688,6 +688,9 @@ class Boldgrid_Inspirations_Update {
 		// Update the recorded previous and current versions in WP options.
 		update_site_option( 'boldgrid_inspirations_previous_version', $current_version );
 		update_site_option( 'boldgrid_inspirations_current_version', $live_version );
+
+		// Update the Onboarding Videos array.
+		update_site_option( 'boldgrid_onboarding_videos', Boldgrid_Inspirations::get_onboarding_videos() );
 	}
 
 	/**

--- a/includes/class-boldgrid-inspirations.php
+++ b/includes/class-boldgrid-inspirations.php
@@ -433,8 +433,16 @@ class Boldgrid_Inspirations {
 	public function get_onboarding_videos() {
 		$config = Boldgrid_Inspirations_Config::get_format_configs();
 
-		if ( isset( $config['onboarding_videos'] ) ) {
-			return $config['onboarding_videos'];
+		$api_call_results = Boldgrid_Inspirations_Api::boldgrid_api_call(
+			$config['ajax_calls']['get-onboarding-videos']
+		);
+
+		if ( 200 !== $api_call_results->status ) {
+			return array();
+		}
+
+		if ( isset( $api_call_results->result->data ) ) {
+			return $api_call_results->result->data;
 		} else {
 			return array();
 		}

--- a/includes/class-boldgrid-inspirations.php
+++ b/includes/class-boldgrid-inspirations.php
@@ -414,10 +414,30 @@ class Boldgrid_Inspirations {
 		update_site_option( 'boldgrid_inspirations_activated_version', $plugin_data['Version'] );
 		update_site_option( 'boldgrid_inspirations_current_version', $plugin_data['Version'] );
 
+		// Update the Onboarding Videos array.
+		update_site_option( 'boldgrid_onboarding_videos', $this->get_onboarding_videos() );
+
 		require_once BOLDGRID_BASE_DIR . '/includes/class-boldgrid-inspirations-attribution.php';
 		require_once BOLDGRID_BASE_DIR . '/includes/class-boldgrid-inspirations-attribution-page.php';
 
 		Boldgrid_Inspirations_Attribution_Page::on_activate();
+	}
+
+	/**
+	 * Get the Onboarding Videos array.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return array
+	 */
+	public function get_onboarding_videos() {
+		$config = Boldgrid_Inspirations_Config::get_format_configs();
+
+		if ( isset( $config['onboarding_videos'] ) ) {
+			return $config['onboarding_videos'];
+		} else {
+			return array();
+		}
 	}
 
 	/**

--- a/includes/class-boldgrid-inspirations.php
+++ b/includes/class-boldgrid-inspirations.php
@@ -415,7 +415,7 @@ class Boldgrid_Inspirations {
 		update_site_option( 'boldgrid_inspirations_current_version', $plugin_data['Version'] );
 
 		// Update the Onboarding Videos array.
-		update_site_option( 'boldgrid_onboarding_videos', $this->get_onboarding_videos() );
+		update_site_option( 'boldgrid_onboarding_videos', self::get_onboarding_videos() );
 
 		require_once BOLDGRID_BASE_DIR . '/includes/class-boldgrid-inspirations-attribution.php';
 		require_once BOLDGRID_BASE_DIR . '/includes/class-boldgrid-inspirations-attribution-page.php';
@@ -426,11 +426,11 @@ class Boldgrid_Inspirations {
 	/**
 	 * Get the Onboarding Videos array.
 	 *
-	 * @since 2.8.0
+	 * @since 2.9.0
 	 *
 	 * @return array
 	 */
-	public function get_onboarding_videos() {
+	public static function get_onboarding_videos() {
 		$config = Boldgrid_Inspirations_Config::get_format_configs();
 
 		$api_call_results = Boldgrid_Inspirations_Api::boldgrid_api_call(

--- a/includes/config/config.onboarding.php
+++ b/includes/config/config.onboarding.php
@@ -443,25 +443,5 @@ return array(
 			),
 		),
 	),
-	'onboarding_videos'          => array(
-		'ppb' => array(
-			array(
-				'id'    => '8tolMBiKSY4',
-				'title' => 'Getting Started with Sections, Rows, and Columns',
-			),
-			array(
-				'id'    => 'rxCwWhFSL1c',
-				'title' => 'Responsive Device Controls',
-			),
-			array(
-				'id'    => 'opXxNHOUr8E',
-				'title' => 'How to Drag and Drop',
-			),
-			array(
-				'id'    => 'uDwQKeFe344',
-				'title' => 'Working with Blocks',
-			),
-		),
-	),
 );
 

--- a/includes/config/config.onboarding.php
+++ b/includes/config/config.onboarding.php
@@ -443,5 +443,17 @@ return array(
 			),
 		),
 	),
+	'onboarding_videos'          => array(
+		'ppb' => array(
+			array(
+				'id'    => '8tolMBiKSY4',
+				'title' => 'Getting Started with Sections, Rows, and Columns',
+			),
+			array(
+				'id'    => 'rxCwWhFSL1c',
+				'title' => 'Responsive Device Controls',
+			),
+		),
+	),
 );
 

--- a/includes/config/config.onboarding.php
+++ b/includes/config/config.onboarding.php
@@ -453,6 +453,14 @@ return array(
 				'id'    => 'rxCwWhFSL1c',
 				'title' => 'Responsive Device Controls',
 			),
+			array(
+				'id'    => 'opXxNHOUr8E',
+				'title' => 'How to Drag and Drop',
+			),
+			array(
+				'id'    => 'uDwQKeFe344',
+				'title' => 'Working with Blocks',
+			),
 		),
 	),
 );

--- a/includes/config/config.plugin.php
+++ b/includes/config/config.plugin.php
@@ -71,6 +71,9 @@ return array(
 
 		// Preview Server.
 		'get-site-content' => 							'/wpb-maintenance/get-site-content.php',
+
+		// Onboarding.
+		'get-onboarding-videos' =>                      '/api/onboarding/get-videos',
 	),
 	'asset_server' =>									'https://wp-assets.boldgrid.com',
 	'preview_server' =>									'https://wp-preview.boldgrid.com',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boldgrid-inspirations",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "BoldGrid Inspirations WordPress plugin",
   "directories": {
     "test": "tests"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: inspiration, customization, build, create, design
 Requires at least: 4.4
 Tested up to: 6.4
 Requires PHP: 5.4
-Stable tag: 2.8.1
+Stable tag: 2.9.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,6 +34,12 @@ The second phase is Customization; tools to transform your website into your vis
 3. You will find the Inspirations menu in your WordPress Dashboard / admin panel.
 
 == Changelog ==
+
+= 2.9.0 =
+
+Release Date: December 4th, 2023
+
+* New Feature: Added onboarding videos that are fetched from the BoldGrid API Server.
 
 = 2.8.1 =
 


### PR DESCRIPTION
# Add Onboarding Tutorial Videos #

## Test Files ##

[post-and-page-builder-1.26.0-rc.1.zip](https://github.com/BoldGrid/post-and-page-builder/files/13516478/post-and-page-builder-1.26.0-rc.1.zip)
[boldgrid-inspirations-2.9.0-rc.1.zip](https://github.com/BoldGrid/post-and-page-builder/files/13516479/boldgrid-inspirations-2.9.0-rc.1.zip)


## Testing Instructions ##

1. Install the test zip files linked above.
2. Open a page or post in Post and Page Builder.
3. You should see the onboarding videos panel display on initial page load.
4. On closing the videos panel, you should see an admin pointer indicating where you can go to re-open the videos
5. Opening the videos panel should show the videos again, but when closing a second time, you should not see the admin pointer.
6. After dismissing the videos panel, subsequent page loads should not automatically display the panel