### PR TITLE
HIde BoldGrid Backup notice on 'my-inspiration' page

### DIFF
--- a/includes/class-boldgrid-inspirations.php
+++ b/includes/class-boldgrid-inspirations.php
@@ -319,6 +319,15 @@ class Boldgrid_Inspirations {
 			), 10, 2
 		);
 
+		// Add the filter to hide BoldGrid Backup notice on 'my-inspiration' page.
+		add_filter( 'boldgrid_backup_post_activate_notice', function( $notice ) {
+			if ( ! empty( $_GET['page'] ) && 'my-inspiration' === $_GET['page'] ) {
+				$notice = '';
+			}
+		
+			return $notice;
+		}, 10, 1 );
+
 		// Create Onboarding Tasks when deployment is complete.
 		add_action(
 			'boldgrid_inspirations_deploy_complete',


### PR DESCRIPTION
Original issue was in BoldGrid Backup Repo - https://github.com/BoldGrid/boldgrid-backup/issues/571

Added a filter that hides the "Create your first backup" message from Inspirations onboarding.