### PR TITLE
add filter to bypass incorrect sanitization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,6 @@ notifications:
 
 matrix:
   include:
-    - php: 5.6
-      before_script:
-        - nvm install 10
-        - nvm use 10
-        - yarn
-        - composer self-update --1
-        # Lock file has phpunit 7. Remove it and install phpunit 5 for php 5.6.
-        - composer remove --dev phpunit/phpunit
-        - composer require --dev phpunit/phpunit ^5
-        - composer install -o
-        - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
     - php: 7.4
       before_script:
         - nvm install 10

--- a/boldgrid-inspirations.php
+++ b/boldgrid-inspirations.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: BoldGrid Inspirations
  * Plugin URI: https://www.boldgrid.com/boldgrid-inspirations/
- * Version: 2.9.1
+ * Version: 2.9.2
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Description: Find inspiration, customize, and launch! BoldGrid Inspirations includes FREE WordPress themes and is the easiest way to launch a new WordPress site complete with custom content.

--- a/includes/class-boldgrid-inspirations.php
+++ b/includes/class-boldgrid-inspirations.php
@@ -324,6 +324,18 @@ class Boldgrid_Inspirations {
 			'boldgrid_inspirations_deploy_complete',
 			array( $this, 'create_onboarding_tasks' )
 		);
+
+		/*
+		 * WP 6.6 added sanitize_text_field() to the autofocus attribute which breaks it, since
+		 * it is an array not a string. This filter will bypass this.
+		 */
+		add_filter( 'sanitize_text_field', function( $filtered, $str ) {
+			if ( isset( $_REQUEST['autofocus'] ) && $_REQUEST['autofocus'] === $str ) {
+				return $str;
+			} else {
+				return $filtered;
+			}
+		}, 10, 2 );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === BoldGrid Inspirations ===
-Contributors: boldgrid, imh_brad, joemoto, rramo012, timph
+Contributors: boldgrid, imh_brad, joemoto, rramo012, timph, jamesros161
 Tags: inspiration, customization, build, create, design
 Requires at least: 4.4
-Tested up to: 6.5
+Tested up to: 6.6
 Requires PHP: 5.4
-Stable tag: 2.9.1
+Stable tag: 2.9.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,6 +34,12 @@ The second phase is Customization; tools to transform your website into your vis
 3. You will find the Inspirations menu in your WordPress Dashboard / admin panel.
 
 == Changelog ==
+
+= 2.9.2 =
+
+Release Date: July 3rd, 2024
+
+* Bug Fix: WP 6.6 - Inspirations onboarding links to Customizer don’t go to correct panel [#202](https://github.com/BoldGrid/boldgrid-inspirations/issues/202)
 
 = 2.9.1 =
 


### PR DESCRIPTION
This resolves #202 . WP6.6 modified wp-admin/customize.php to sanitize the query strings for the query string parameters. However, the autofocus parameter is an array not a string, so it always fails sanitization. A core ticket was created for this here: https://core.trac.wordpress.org/ticket/61561#ticket 

In the meantime, this workaround will bypass the sanitization