### PR TITLE
WP 6.7 - Function load_plugin_textdomain was called incorrectly

### DIFF
--- a/boldgrid-inspirations.php
+++ b/boldgrid-inspirations.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: BoldGrid Inspirations
  * Plugin URI: https://www.boldgrid.com/boldgrid-inspirations/
- * Version: 2.9.2
+ * Version: 2.9.3
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * Description: Find inspiration, customize, and launch! BoldGrid Inspirations includes FREE WordPress themes and is the easiest way to launch a new WordPress site complete with custom content.

--- a/includes/class-boldgrid-inspirations-api.php
+++ b/includes/class-boldgrid-inspirations-api.php
@@ -381,7 +381,7 @@ class Boldgrid_Inspirations_Api {
 			}
 
 			// Get the installed plugin data.
-			$plugin_data = get_plugin_data( BOLDGRID_BASE_DIR . '/boldgrid-inspirations.php', false );
+			$plugin_data = get_plugin_data( BOLDGRID_BASE_DIR . '/boldgrid-inspirations.php', false, false );
 
 			$params_array['installed_core_version'] = $plugin_data['Version'];
 

--- a/includes/class-boldgrid-inspirations.php
+++ b/includes/class-boldgrid-inspirations.php
@@ -289,7 +289,7 @@ class Boldgrid_Inspirations {
 		);
 
 		// After plugins have been loaded, load the textdomain.
-		add_action( 'plugins_loaded',
+		add_action( 'after_setup_theme',
 			array(
 				$this,
 				'boldgrid_load_textdomain',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boldgrid-inspirations",
-  "version": "2.9.1",
+  "version": "2.9.3",
   "description": "BoldGrid Inspirations WordPress plugin",
   "directories": {
     "test": "tests"

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: boldgrid, imh_brad, joemoto, rramo012, timph, jamesros161
 Tags: inspiration, customization, build, create, design
 Requires at least: 4.4
-Tested up to: 6.6
+Tested up to: 6.7
 Requires PHP: 5.4
-Stable tag: 2.9.2
+Stable tag: 2.9.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,6 +34,12 @@ The second phase is Customization; tools to transform your website into your vis
 3. You will find the Inspirations menu in your WordPress Dashboard / admin panel.
 
 == Changelog ==
+
+= 2.9.3 =
+
+Release Date: November 7th, 2024
+
+* Bug Fix: WP 6.7 - Function load_plugin_textdomain was called incorrectly [#205](https://github.com/BoldGrid/boldgrid-inspirations/issues/205)
 
 = 2.9.2 =
 


### PR DESCRIPTION
Resolves #205

Test File: [boldgrid-inspirations-2.9.3-issue-205.zip](https://github.com/user-attachments/files/17284280/boldgrid-inspirations-2.9.3-issue-205.zip)
