### PR TITLE
Updated the Support URL.

### DIFF
--- a/includes/config/config.onboarding.php
+++ b/includes/config/config.onboarding.php
@@ -436,7 +436,7 @@ return array(
 			'buttons'     => array(
 				array(
 					'text'   => __( 'Learn More', 'boldgrid-inspirations' ),
-					'url'    => boldgrid_inspirations_get_premium_url(),
+					'url'    => 'https://support.boldgrid.com/open.php',
 					'class'  => 'button-secondary',
 					'target' => '_blank',
 				),


### PR DESCRIPTION
Didn't change the function because others need to access central, just updated the link to direct premium support.


wp-admin/admin.php?page=my-inspiration

![image](https://github.com/user-attachments/assets/f31bd759-8b0f-45d5-8ab4-d6c9f9d1ce1e)
